### PR TITLE
Info image route

### DIFF
--- a/imgserve.go
+++ b/imgserve.go
@@ -4,8 +4,15 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/exec"
+	"strings"
 
 	flag "github.com/spf13/pflag"
+)
+
+var (
+	imagesInfo = make(map[string][]byte)
 )
 
 func main() {
@@ -13,7 +20,52 @@ func main() {
 	directory := flag.StringP("directory", "D", ".", "the directory of static file to host")
 	flag.Parse()
 
+	initRoutes(*directory)
 	addr := fmt.Sprintf(":%d", *port)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
 
-	log.Fatal(http.ListenAndServe(addr, http.FileServer(http.Dir(*directory))))
+//initRoutes initializes all routes
+func initRoutes(directory string) {
+	http.Handle("/", http.FileServer(http.Dir(directory)))
+	http.HandleFunc("/info/", func(w http.ResponseWriter, r *http.Request) {
+		getImageInfo(w, r, directory)
+	})
+}
+
+//getImageInfo returns info about image
+func getImageInfo(w http.ResponseWriter, r *http.Request, directory string) {
+	imageName := strings.TrimPrefix(r.URL.Path, "/info/")
+	if imageName == "" {
+		w.Write([]byte("name can not be empty"))
+		return
+	}
+
+	if value, ok := imagesInfo[imageName]; ok {
+		w.Write(value)
+		return
+	}
+
+	imagePath := directory + "/" + imageName
+	if _, err := os.Stat(imagePath); os.IsNotExist(err) {
+		w.Write([]byte("image does not exists"))
+		return
+	}
+
+	cmdName := "qemu-img"
+	cmdArgs := []string{"info", imagePath, "--output=json"}
+	cmd := exec.Command(cmdName, cmdArgs...)
+
+	var (
+		cmdOut []byte
+		err    error
+	)
+	if cmdOut, err = cmd.Output(); err != nil {
+		w.Write([]byte(fmt.Sprintf("error while reading output of qemu-img command: %v", err.Error())))
+		return
+	}
+
+	imagesInfo[imageName] = cmdOut
+
+	w.Write(cmdOut)
 }


### PR DESCRIPTION
Add info route to script. This route tries to find image in given directory and if it exists, it runs `qemu-img info` command and returns command's output.