### PR TITLE
add logging middleware

### DIFF
--- a/imgserve.go
+++ b/imgserve.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	flag "github.com/spf13/pflag"
 )
@@ -27,10 +30,58 @@ func main() {
 
 //initRoutes initializes all routes
 func initRoutes(directory string) {
-	http.Handle("/", http.FileServer(http.Dir(directory)))
+	http.Handle("/", logInfo(http.FileServer(http.Dir(directory)), directory))
 	http.HandleFunc("/info/", func(w http.ResponseWriter, r *http.Request) {
 		getImageInfo(w, r, directory)
 	})
+}
+
+func logInfo(next http.Handler, directory string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timeStart := time.Now()
+		clientID := "clientID: " + r.RemoteAddr
+		log.Println(clientID + ", start: " + timeStart.Format(time.RFC3339))
+		next.ServeHTTP(w, r)
+
+		timeEnd := time.Now()
+		log.Println(clientID + ", end: " + timeEnd.Format(time.RFC3339))
+
+		imageName := strings.TrimPrefix(r.URL.Path, "/")
+		if imageName == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("name can not be empty"))
+			return
+		}
+
+		averageSpeed, err := countAverageSpeed(directory, imageName, timeEnd.Unix()-timeStart.Unix())
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("error while calculating average speed, %v", err.Error())))
+			return
+		}
+		log.Println(clientID+", average speed: ", averageSpeed/1000, "kB/s")
+	})
+}
+
+//countAverageSpeed counts average speed of downloading image.
+//it counts sizeOfImage(bytes)/durationOfDownload(seconds)
+func countAverageSpeed(directory, imageName string, duration int64) (int64, error) {
+	if _, ok := imagesInfo[imageName]; !ok {
+		err := getInfo(directory, imageName)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	data := make(map[string]interface{})
+	err := json.Unmarshal(imagesInfo[imageName], &data)
+	if err != nil {
+		return 0, err
+	}
+
+	size := int64(data["virtual-size"].(float64))
+	averageSpeed := size / duration
+	return averageSpeed, nil
 }
 
 //getImageInfo returns info about image
@@ -48,11 +99,21 @@ func getImageInfo(w http.ResponseWriter, r *http.Request, directory string) {
 		return
 	}
 
+	err := getInfo(directory, imageName)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(imagesInfo[imageName])
+}
+
+func getInfo(directory, imageName string) error {
 	imagePath := directory + "/" + imageName
 	if _, err := os.Stat(imagePath); os.IsNotExist(err) {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("image does not exists"))
-		return
+		return errors.New("image not found")
 	}
 
 	cmdName := "qemu-img"
@@ -64,12 +125,9 @@ func getImageInfo(w http.ResponseWriter, r *http.Request, directory string) {
 		err    error
 	)
 	if cmdOut, err = cmd.Output(); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf("error while reading output of qemu-img command: %v", err.Error())))
-		return
+		return fmt.Errorf("error while reading output of qemu-img command: %v", err.Error())
 	}
 
 	imagesInfo[imageName] = cmdOut
-	w.WriteHeader(http.StatusOK)
-	w.Write(cmdOut)
+	return nil
 }

--- a/imgserve.go
+++ b/imgserve.go
@@ -55,8 +55,7 @@ func logInfo(next http.Handler, directory string) http.Handler {
 
 		averageSpeed, err := countAverageSpeed(directory, imageName, timeEnd.Unix()-timeStart.Unix())
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(fmt.Sprintf("error while calculating average speed, %v", err.Error())))
+			log.Println("error while calculating average speed: ", err.Error())
 			return
 		}
 		log.Println(clientID+", average speed: ", averageSpeed/1000, "kB/s")


### PR DESCRIPTION
add logging middleware for loggin start, end time and average speed of image downloading.
Output in format: 
2018/09/21 13:05:16 clientID: [::1]:56558, start: 2018-09-21T13:05:16+02:00
2018/09/21 13:06:23 clientID: [::1]:56558, end: 2018-09-21T13:06:23+02:00
2018/09/21 13:06:23 clientID: [::1]:56558, average speed:  160259 kB/s
